### PR TITLE
♻️ refactor(file-manager): improve locking and writing logic for file…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor
 composer.lock
 git-story_media
 test.php
+diff.txt

--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@
 
 Pathwise is a robust PHP library designed for streamlined file and directory management. With features like safe reading/writing, metadata extraction, path utilities, compression, and permission management, it ensures a developer-friendly experience while handling complex file operations.
 
-
-
 ## **Table of Contents**
 1. [Introduction](#pathwise-file-management-made-simple)
 2. [Prerequisites](#prerequisites)
@@ -32,8 +30,6 @@ Pathwise is a robust PHP library designed for streamlined file and directory man
     - [File and Directory Utilities](#file-and-directory-utilities)
 9. [Support](#support)
 10. [License](#license)
-
-
 
 ## **Prerequisites**
 - Language: PHP 8.2/+

--- a/src/FileManager/SafeFileReader.php
+++ b/src/FileManager/SafeFileReader.php
@@ -138,7 +138,7 @@ final class SafeFileReader implements Countable, Iterator, SeekableIterator
      */
     public function releaseLock(): void
     {
-        if ($this->isLocked) {
+        if ($this->isLocked && isset($this->file)) {
             $this->file->flock(LOCK_UN);
             $this->isLocked = false;
         }


### PR DESCRIPTION
… operations

- Updated `SafeFileReader` to ensure locks are released only when files are properly initialized.
- Enhanced the `SafeFileWriter` lock mechanism to increase retries from 3 to 5 and delay from 100ms to 200ms for better robustness.
- Removed redundant try-finally block in the `__call` method of `SafeFileWriter`.
- Changed write methods to return the actual number of bytes written (`int|false`) instead of boolean, improving API clarity and usability.
- Added exceptions to the destructor in `SafeFileWriter` to handle potential resource issues during cleanup.

BREAKING CHANGE: Modified the return type of multiple private write methods in `SafeFileWriter` from `bool` to `int|false`. This impacts integrations relying on previous boolean responses.